### PR TITLE
Added useEffect to change the activeItemId when re-rendering

### DIFF
--- a/source/side-nav.tsx
+++ b/source/side-nav.tsx
@@ -42,8 +42,8 @@ const Navigation: React.FC<SideNavProps> = ({
     setActiveSubNav((originalSubNav) => ({
       expanded: originalSubNav.expanded,
       selectedId: activeItemId,
-    }))
-  }, [activeItemId])
+    }));
+  }, [activeItemId]);
 
   function handleClick(itemId: string): void {
     if (onSelect) {

--- a/source/side-nav.tsx
+++ b/source/side-nav.tsx
@@ -38,6 +38,13 @@ const Navigation: React.FC<SideNavProps> = ({
     selectedId: activeItemId,
   });
 
+  React.useEffect(() => {
+    setActiveSubNav((originalSubNav) => ({
+      expanded: originalSubNav.expanded,
+      selectedId: activeItemId,
+    }))
+  }, [activeItemId])
+
   function handleClick(itemId: string): void {
     if (onSelect) {
       onSelect({itemId});


### PR DESCRIPTION
Hello, thank you for your great application. It's great that I could meet this app.

Actually, I found a bug that does not work `activeItemId` when I assign a new value into the `activeItemId` prop of the `<Navigation>` component.

I think it's because parameters of useState are fixed when the `<Navigation>` component is rendered at the beginning.

↓ Here is a video about my local development reproducing this problem.
https://user-images.githubusercontent.com/5797788/106006916-13c91300-60f9-11eb-8101-9569207ad1e4.mov

↓ This is a similar issue to pass initial values into parameters of `useState`. I did not use `react-minimal-side-navigation` there, however, this similarity might be helpful.
https://codesandbox.io/s/react-minimal-side-navigation-like-issue-jiggj

I believe, in this case, `React.useEffect` is the most appropriate revise. This PR is one of the answers to resolve it.
By the way, I have no idea why the following issue happened, but this PR might solve it.
https://github.com/abhijithvijayan/react-minimal-side-navigation/issues/5

I hope this PR will be merged.