### PR TITLE
Feat: Add optional html id to nav item

### DIFF
--- a/source/side-nav.tsx
+++ b/source/side-nav.tsx
@@ -17,6 +17,7 @@ declare global {
 export type NavItemProps = {
   title: string;
   itemId: string;
+  htmlId?: string;
   // disabled?: boolean;
   elemBefore?: React.FC<unknown>;
   subNav?: NavItemProps[];
@@ -107,6 +108,7 @@ const Navigation: React.FC<SideNavProps> = ({
               <ul key={item.itemId} className="side-navigation-panel-select">
                 <li className="side-navigation-panel-select-wrap">
                   <div
+				    id={item.htmlId}
                     onClick={(): void => {
                       handleSubNavExpand(item);
                       handleClick(item.itemId);


### PR DESCRIPTION
For testing purpose in our application, it would be helpfull to have HTML ids on menu items.

This pull request simply adds an optional field `htmlId` that is passed as id to the clickable element.